### PR TITLE
Use sha256 hash algorithm with pypiserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - type: bind
         source: ./data/packages
         target: /packages
-    command: -a . -P . /packages
+    command: --hash-algo=sha256 -a . -P . /packages
     networks:
       - pypiserver_network
 


### PR DESCRIPTION
Poetry >= 1.2 does not support md5 hashes anymore and thus we should switch to sha256

Related optinode PR: https://github.com/node-energy/optinode_backend/pull/6489

## Deployment notes

Once this is merged and rolled out to pypi.node.energy we need to merge the linked PR in optinode. Any subsequent PR builds of optinode_backend will need to include the changed hash-values otherwise the build will fail. I suggest to make an announcement in Teams - Development channel once this is rolled out